### PR TITLE
Fix missing analysis endpoints

### DIFF
--- a/frontend/analysis.js
+++ b/frontend/analysis.js
@@ -7,6 +7,13 @@ export async function showAnalysis() {
   renderRecurring(freq);
 }
 
+// Automatically fetch and display charts when the page is loaded
+document.addEventListener("DOMContentLoaded", () => {
+  showAnalysis().catch(() => {
+    console.error("Failed to load analysis data");
+  });
+});
+
 function renderChart(data) {
   const ctx = document.getElementById("scoreChart").getContext("2d");
   new Chart(ctx, {

--- a/main.py
+++ b/main.py
@@ -68,6 +68,18 @@ def list_reports(storage: ReportStorage = Depends(get_storage)):
     return storage.get_all_reports()
 
 
+@app.get("/analysis/scores")
+def analysis_scores(storage: ReportStorage = Depends(get_storage)):
+    """Return historical score breakdown for charting."""
+    return storage.get_score_history()
+
+
+@app.get("/analysis/frequency")
+def analysis_frequency(storage: ReportStorage = Depends(get_storage)):
+    """Return recurring findings aggregated across reports."""
+    return storage.get_recurring_findings()
+
+
 @app.get("/analyze")
 def analyze_page():
     # Serve the standalone analysis page


### PR DESCRIPTION
## Summary
- provide `/analysis/scores` and `/analysis/frequency` API endpoints
- automatically show charts on the analysis page

## Testing
- `ruff check .`
- `python -m py_compile main.py models.py parser.py storage.py`


------
https://chatgpt.com/codex/tasks/task_e_6876731542d4832d85e7077a5e3c4ea3