### PR TITLE
Optimize reports endpoint

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -73,10 +73,8 @@ function setupGlobalSearch() {
 async function loadReports() {
   const res = await fetch("/reports");
   const reports = await res.json();
-    // Sort by report_date ascending
-  reports.sort((a, b) => 
-    new Date(a.report_date) - new Date(b.report_date)
-  );
+  // Sort by report_date ascending
+  reports.sort((a, b) => new Date(a.report_date) - new Date(b.report_date));
   const tbody = document.querySelector("#reports-table tbody");
   tbody.innerHTML = "";
   reports.forEach(r => {
@@ -98,12 +96,13 @@ async function loadReports() {
     tbody.appendChild(tr);
   });
   tbody.querySelectorAll(".icon-btn[data-id]").forEach(btn => {
-    btn.addEventListener("click", () => showDetails(btn.dataset.id, reports));
+    btn.addEventListener("click", () => showDetails(btn.dataset.id));
   });
 }
 
-function showDetails(id, reports) {
-  const report = reports.find(r => r.id === id);
+async function showDetails(id) {
+  const res = await fetch(`/reports/${id}`);
+  const report = await res.json();
   window.currentReport = report;
   document.getElementById("sort-select").value = 'category';
   renderFindings(report, 'category');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,7 +34,7 @@
     </header>
     <div class="content">
       <!-- Upload -->
-      <section class="card" id="upload-section">
+      <section class="card upload-card" id="upload-section">
         <h2>Upload a PingCastle Report</h2>
         <div class="dropzone" id="dropzone">
           <i class="fas fa-cloud-upload-alt fa-3x"></i>
@@ -44,7 +44,7 @@
         <div id="upload-status" class="status"></div>
       </section>
       <!-- Reports -->
-      <section class="card hidden" id="reports-section">
+      <section class="card reports-card hidden" id="reports-section">
         <div class="card-header">
           <h2>Existing Reports</h2>
           <div class="controls">

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from typing import List
 
-from models import Report
+from models import Report, ReportSummary
 from storage import ReportStorage, get_storage
 from parser import PingCastleParser
 
@@ -63,9 +63,17 @@ async def upload_pingcastle_report(
     return JSONResponse({"status": "success", "report_id": report.id})
 
 
-@app.get("/reports", response_model=List[Report])
+@app.get("/reports", response_model=List[ReportSummary])
 def list_reports(storage: ReportStorage = Depends(get_storage)):
-    return storage.get_all_reports()
+    return storage.get_all_reports_summary()
+
+
+@app.get("/reports/{report_id}", response_model=Report)
+def get_report(report_id: str, storage: ReportStorage = Depends(get_storage)):
+    try:
+        return storage.get_report(report_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Report not found")
 
 
 @app.get("/analysis/scores")

--- a/models.py
+++ b/models.py
@@ -10,6 +10,22 @@ class Finding(BaseModel):
     score: int
     description: str
 
+
+class ReportSummary(BaseModel):
+    """Lightweight representation used for listings."""
+    id: str
+    domain: str
+    report_date: datetime
+    upload_date: datetime
+    global_score: int
+    high_score: int
+    medium_score: int
+    low_score: int
+    stale_objects_score: int
+    privileged_accounts_score: int
+    trusts_score: int
+    anomalies_score: int
+
 class Report(BaseModel):
     id: str
     domain: str


### PR DESCRIPTION
## Summary
- add `ReportSummary` model for lighter listings
- add `/reports/{report_id}` endpoint and modify `/reports` to return summaries
- fetch details lazily in the frontend
- tweak HTML classes to use existing styles

## Testing
- `python -m py_compile main.py models.py parser.py storage.py`


------
https://chatgpt.com/codex/tasks/task_e_68767c2eabc0832d9688a30b0d031b7a