### PR TITLE
Improve DB access

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -13,93 +13,88 @@ class ReportStorage:
         self._create_tables()
 
     def _create_tables(self):
-        conn = sqlite3.connect(self.db_path)
-        c = conn.cursor()
-        c.execute("""
-            CREATE TABLE IF NOT EXISTS reports (
-                id TEXT PRIMARY KEY,
-                domain TEXT,
-                report_date TEXT,
-                upload_date TEXT,
-                global_score INTEGER,
-                high_score INTEGER,
-                medium_score INTEGER,
-                low_score INTEGER,
-                stale_objects_score INTEGER,
-                privileged_accounts_score INTEGER,
-                trusts_score INTEGER,
-                anomalies_score INTEGER,
-                original_file TEXT
-            )
-        """)
-        c.execute("""
-            CREATE TABLE IF NOT EXISTS findings (
-                id TEXT PRIMARY KEY,
-                report_id TEXT,
-                category TEXT,
-                name TEXT,
-                score INTEGER,
-                description TEXT,
-                FOREIGN KEY(report_id) REFERENCES reports(id)
-            )
-        """)
-        conn.commit()
-        conn.close()
+        with sqlite3.connect(self.db_path) as conn:
+            c = conn.cursor()
+            c.execute("""
+                CREATE TABLE IF NOT EXISTS reports (
+                    id TEXT PRIMARY KEY,
+                    domain TEXT,
+                    report_date TEXT,
+                    upload_date TEXT,
+                    global_score INTEGER,
+                    high_score INTEGER,
+                    medium_score INTEGER,
+                    low_score INTEGER,
+                    stale_objects_score INTEGER,
+                    privileged_accounts_score INTEGER,
+                    trusts_score INTEGER,
+                    anomalies_score INTEGER,
+                    original_file TEXT
+                )
+            """)
+            c.execute("""
+                CREATE TABLE IF NOT EXISTS findings (
+                    id TEXT PRIMARY KEY,
+                    report_id TEXT,
+                    category TEXT,
+                    name TEXT,
+                    score INTEGER,
+                    description TEXT,
+                    FOREIGN KEY(report_id) REFERENCES reports(id)
+                )
+            """)
 
     def save_report(self, report: Report):
-        conn = sqlite3.connect(self.db_path)
-        c = conn.cursor()
-        c.execute("""
-            INSERT INTO reports (
-                id, domain, report_date, upload_date,
-                global_score, high_score, medium_score, low_score,
-                stale_objects_score, privileged_accounts_score,
-                trusts_score, anomalies_score,
-                original_file
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """, (
-            report.id,
-            report.domain,
-            report.report_date.isoformat(),
-            report.upload_date.isoformat(),
-            report.global_score,
-            report.high_score,
-            report.medium_score,
-            report.low_score,
-            report.stale_objects_score,
-            report.privileged_accounts_score,
-            report.trusts_score,
-            report.anomalies_score,
-            report.original_file
-        ))
-        for f in report.findings:
+        with sqlite3.connect(self.db_path) as conn:
+            c = conn.cursor()
             c.execute("""
-                INSERT INTO findings
-                (id, report_id, category, name, score, description)
-                VALUES (?, ?, ?, ?, ?, ?)
-            """, (f.id, f.report_id, f.category, f.name, f.score, f.description))
-        conn.commit()
-        conn.close()
+                INSERT INTO reports (
+                    id, domain, report_date, upload_date,
+                    global_score, high_score, medium_score, low_score,
+                    stale_objects_score, privileged_accounts_score,
+                    trusts_score, anomalies_score,
+                    original_file
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                report.id,
+                report.domain,
+                report.report_date.isoformat(),
+                report.upload_date.isoformat(),
+                report.global_score,
+                report.high_score,
+                report.medium_score,
+                report.low_score,
+                report.stale_objects_score,
+                report.privileged_accounts_score,
+                report.trusts_score,
+                report.anomalies_score,
+                report.original_file
+            ))
+            for f in report.findings:
+                c.execute("""
+                    INSERT INTO findings
+                    (id, report_id, category, name, score, description)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                """, (f.id, f.report_id, f.category, f.name, f.score, f.description))
 
     def get_all_reports(self) -> List[Report]:
-        conn = sqlite3.connect(self.db_path)
-        c = conn.cursor()
-        c.execute("SELECT * FROM reports")
-        rows = c.fetchall()
+        with sqlite3.connect(self.db_path) as conn:
+            c = conn.cursor()
+            c.execute("SELECT * FROM reports")
+            report_rows = c.fetchall()
+
+            # Fetch all findings at once and group them by report_id
+            c.execute("SELECT * FROM findings")
+            finding_rows = c.fetchall()
+
+        findings_by_report = {}
+        for f in finding_rows:
+            f_obj = Finding(id=f[0], report_id=f[1], category=f[2],
+                            name=f[3], score=f[4], description=f[5])
+            findings_by_report.setdefault(f_obj.report_id, []).append(f_obj)
+
         reports: List[Report] = []
-        for row in rows:
-            # row indices now shifted by 4 new columns:
-            # 0:id,1:domain,2:report_date,3:upload_date,
-            # 4:global,5:high,6:medium,7:low,
-            # 8:stale,9:privileged,10:trusts,11:anomalies,12:original_file
-            report_id = row[0]
-            c.execute("SELECT * FROM findings WHERE report_id = ?", (report_id,))
-            fr = c.fetchall()
-            findings = [
-                Finding(id=f[0], report_id=f[1], category=f[2],
-                        name=f[3], score=f[4], description=f[5])
-                for f in fr
-            ]
+        for row in report_rows:
             reports.append(Report(
                 id=row[0],
                 domain=row[1],
@@ -114,21 +109,20 @@ class ReportStorage:
                 trusts_score=row[10],
                 anomalies_score=row[11],
                 original_file=row[12],
-                findings=findings
+                findings=findings_by_report.get(row[0], [])
             ))
-        conn.close()
+
         return reports
 
     def get_all_reports_summary(self) -> List[ReportSummary]:
-        conn = sqlite3.connect(self.db_path)
-        c = conn.cursor()
-        c.execute(
-            "SELECT id, domain, report_date, upload_date, global_score, high_score, "
-            "medium_score, low_score, stale_objects_score, privileged_accounts_score, "
-            "trusts_score, anomalies_score FROM reports"
-        )
-        rows = c.fetchall()
-        conn.close()
+        with sqlite3.connect(self.db_path) as conn:
+            c = conn.cursor()
+            c.execute(
+                "SELECT id, domain, report_date, upload_date, global_score, high_score, "
+                "medium_score, low_score, stale_objects_score, privileged_accounts_score, "
+                "trusts_score, anomalies_score FROM reports"
+            )
+            rows = c.fetchall()
         return [
             ReportSummary(
                 id=row[0],
@@ -148,20 +142,18 @@ class ReportStorage:
         ]
 
     def get_report(self, report_id: str) -> Report:
-        conn = sqlite3.connect(self.db_path)
-        c = conn.cursor()
-        c.execute("SELECT * FROM reports WHERE id = ?", (report_id,))
-        row = c.fetchone()
-        if not row:
-            conn.close()
-            raise ValueError("Report not found")
-        c.execute("SELECT * FROM findings WHERE report_id = ?", (report_id,))
-        fr = c.fetchall()
+        with sqlite3.connect(self.db_path) as conn:
+            c = conn.cursor()
+            c.execute("SELECT * FROM reports WHERE id = ?", (report_id,))
+            row = c.fetchone()
+            if not row:
+                raise ValueError("Report not found")
+            c.execute("SELECT * FROM findings WHERE report_id = ?", (report_id,))
+            fr = c.fetchall()
         findings = [
             Finding(id=f[0], report_id=f[1], category=f[2], name=f[3], score=f[4], description=f[5])
             for f in fr
         ]
-        conn.close()
         return Report(
             id=row[0],
             domain=row[1],
@@ -180,16 +172,15 @@ class ReportStorage:
         )
 
     def get_score_history(self) -> List[Dict]:
-        conn = sqlite3.connect(self.db_path)
-        c = conn.cursor()
-        c.execute("""
-          SELECT report_date, stale_objects_score,
-                 privileged_accounts_score, trusts_score, anomalies_score
-          FROM reports
-          ORDER BY report_date
-        """)
-        rows = c.fetchall()
-        conn.close()
+        with sqlite3.connect(self.db_path) as conn:
+            c = conn.cursor()
+            c.execute("""
+              SELECT report_date, stale_objects_score,
+                     privileged_accounts_score, trusts_score, anomalies_score
+              FROM reports
+              ORDER BY report_date
+            """)
+            rows = c.fetchall()
         return [
           {
             "date": row[0],
@@ -202,16 +193,15 @@ class ReportStorage:
         ]
 
     def get_recurring_findings(self) -> List[Dict]:
-        conn = sqlite3.connect(self.db_path)
-        c = conn.cursor()
-        c.execute("""
-          SELECT category, name, COUNT(*) as count
-          FROM findings
-          GROUP BY category, name
-          ORDER BY count DESC
-        """)
-        rows = c.fetchall()
-        conn.close()
+        with sqlite3.connect(self.db_path) as conn:
+            c = conn.cursor()
+            c.execute("""
+              SELECT category, name, COUNT(*) as count
+              FROM findings
+              GROUP BY category, name
+              ORDER BY count DESC
+            """)
+            rows = c.fetchall()
         return [
           {"category": row[0], "name": row[1], "count": row[2]}
           for row in rows


### PR DESCRIPTION
## Summary
- optimize queries to avoid N+1 lookups
- use sqlite context managers for cleaner commits

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6878bc36745c832d95627a4bfa791c56