### PR TITLE
Refactor UI with dedicated pages

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -71,7 +71,7 @@ function setupGlobalSearch() {
 }
 
 async function loadReports() {
-  const res = await fetch("/reports");
+  const res = await fetch("/api/reports");
   const reports = await res.json();
   // Sort by report_date ascending
   reports.sort((a, b) => new Date(a.report_date) - new Date(b.report_date));
@@ -79,6 +79,7 @@ async function loadReports() {
   tbody.innerHTML = "";
   reports.forEach(r => {
     const tr = document.createElement("tr");
+    tr.dataset.id = r.id;
     tr.innerHTML = `
       <td>${r.domain}</td>
       <td>${new Date(r.report_date).toLocaleDateString()}</td>
@@ -87,21 +88,16 @@ async function loadReports() {
       <td>${r.privileged_accounts_score}</td>
       <td>${r.trusts_score}</td>
       <td>${r.anomalies_score}</td>
-      <td>
-        <button class="icon-btn" data-id="${r.id}" title="Details">
-          <i class="fas fa-search"></i>
-        </button>
-      </td>
     `;
     tbody.appendChild(tr);
   });
-  tbody.querySelectorAll(".icon-btn[data-id]").forEach(btn => {
-    btn.addEventListener("click", () => showDetails(btn.dataset.id));
+  tbody.querySelectorAll("tr[data-id]").forEach(tr => {
+    tr.addEventListener("click", () => showDetails(tr.dataset.id));
   });
 }
 
 async function showDetails(id) {
-  const res = await fetch(`/reports/${id}`);
+  const res = await fetch(`/api/reports/${id}`);
   const report = await res.json();
   window.currentReport = report;
   document.getElementById("sort-select").value = 'category';
@@ -136,7 +132,7 @@ function renderFindings(report, sortKey) {
 }
 
 function exportCSV() {
-  fetch("/reports")
+  fetch("/api/reports")
     .then(r => r.json())
     .then(reports => {
       const headers = ["domain","report_date","global_score","stale_objects_score","privileged_accounts_score","trusts_score","anomalies_score"];

--- a/frontend/home.js
+++ b/frontend/home.js
@@ -1,0 +1,20 @@
+import { showAnalysis } from './analysis.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  await showAnalysis().catch(() => console.error('Failed to load analysis data'));
+  loadDomainInfo();
+});
+
+async function loadDomainInfo() {
+  try {
+    const res = await fetch('/api/reports');
+    const reports = await res.json();
+    if (reports.length) {
+      const latest = reports[reports.length - 1];
+      document.getElementById('domain-name').textContent = latest.domain;
+      document.getElementById('latest-date').textContent = new Date(latest.report_date).toLocaleDateString();
+    }
+  } catch {
+    // ignore
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8" />
   <title>Donwatcher Dashboard</title>
-  <!-- Chart.js & FontAwesome -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="styles.css" />
@@ -16,101 +15,25 @@
       <a href="/" class="nav-item active"><i class="fas fa-tachometer-alt"></i><span>Dashboard</span></a>
       <a href="/reports" class="nav-item" id="nav-reports"><i class="fas fa-file-alt"></i><span>Reports</span></a>
       <a href="/analyze" class="nav-item"><i class="fas fa-chart-line"></i><span>Analyze</span></a>
-      <a href="#" class="nav-item"><i class="fas fa-cog"></i><span>Settings</span></a>
-      <a href="#" class="nav-item"><i class="fas fa-sign-out-alt"></i><span>Logout</span></a>
     </nav>
   </aside>
   <div class="main">
     <header class="topbar">
-      <div class="topbar-search">
-        <i class="fas fa-search"></i>
-        <input type="text" id="global-search" placeholder="Search…" />
-      </div>
-      <div class="topbar-actions">
-        <i class="far fa-bell"></i>
-        <i class="fas fa-question-circle"></i>
-        <i class="far fa-user-circle avatar"></i>
-      </div>
+      <h1>Dashboard</h1>
     </header>
     <div class="content">
-      <!-- Upload -->
-      <section class="card upload-card" id="upload-section">
-        <h2>Upload a PingCastle Report</h2>
-        <div class="dropzone" id="dropzone">
-          <i class="fas fa-cloud-upload-alt fa-3x"></i>
-          <p>Drag &amp; drop or click to browse</p>
-          <input type="file" id="file-input" accept=".xml,.html" hidden />
-        </div>
-        <div id="upload-status" class="status"></div>
+      <section class="card" id="domain-info">
+        <h2>Domain Information</h2>
+        <p>Domain: <span id="domain-name">-</span></p>
+        <p>Latest Scan: <span id="latest-date">-</span></p>
       </section>
-      <!-- Reports -->
-      <section class="card reports-card hidden" id="reports-section">
-        <div class="card-header">
-          <h2>Existing Reports</h2>
-          <div class="controls">
-            <input type="text" id="table-search" placeholder="Search reports…" />
-            <button id="export-btn"><i class="fas fa-file-export"></i> Export</button>
-          </div>
-        </div>
-        <div class="table-wrap">
-          <table id="reports-table">
-            <thead>
-              <tr>
-                <th>Domain</th><th>Date</th><th>Global</th>
-                <th>StaleObjects</th><th>PrivilegedAccounts</th>
-                <th>Trusts</th><th>Anomalies</th><th>Actions</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
-        </div>
-      </section>
-      <!-- Analyze -->
-      <section class="card hidden" id="analyze-section">
-        <div class="card-header"><h2>Analysis</h2></div>
+      <section class="card" id="analyze-section">
+        <div class="card-header"><h2>Score History</h2></div>
         <div class="chart-wrap"><canvas id="scoreChart"></canvas></div>
-        <div class="recurring-wrap">
-          <h3>Recurring Findings</h3>
-          <table id="recurring-table">
-            <thead><tr><th>Category</th><th>Name</th><th>Count</th></tr></thead>
-            <tbody></tbody>
-          </table>
-        </div>
       </section>
     </div>
   </div>
 </div>
-<!-- Details modal -->
-<div id="modal" class="modal hidden">
-  <div class="modal-content">
-    <span id="modal-close" class="modal-close">&times;</span>
-    <h2>Report Details</h2>
-    <div class="sort-controls">
-      <label for="sort-select">Sort by:</label>
-      <select id="sort-select">
-        <option value="category">Category</option>
-        <option value="name">Name</option>
-        <option value="score_desc">Score (high→low)</option>
-        <option value="score_asc">Score (low→high)</option>
-      </select>
-    </div>
-    <div class="table-wrap">
-      <table id="findings-table">
-        <thead>
-          <tr>
-            <th>Category</th>
-            <th>Name</th>
-            <th>Score</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody></tbody>
-      </table>
-    </div>
-  </div>
-</div>
-<!-- Scripts -->
-<script type="module" src="app.js"></script>
-<script type="module" src="analysis.js"></script>
+<script type="module" src="home.js"></script>
 </body>
 </html>

--- a/frontend/reports.html
+++ b/frontend/reports.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Donwatcher Reports</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<div class="app">
+  <aside class="sidebar">
+    <div class="logo">Donwatcher</div>
+    <nav>
+      <a href="/" class="nav-item"><i class="fas fa-tachometer-alt"></i><span>Dashboard</span></a>
+      <a href="/reports" class="nav-item active" id="nav-reports"><i class="fas fa-file-alt"></i><span>Reports</span></a>
+      <a href="/analyze" class="nav-item"><i class="fas fa-chart-line"></i><span>Analyze</span></a>
+    </nav>
+  </aside>
+  <div class="main">
+    <header class="topbar">
+      <div class="topbar-search">
+        <i class="fas fa-search"></i>
+        <input type="text" id="global-search" placeholder="Search…" />
+      </div>
+    </header>
+    <div class="content">
+      <section class="card upload-card" id="upload-section">
+        <h2>Upload a PingCastle Report</h2>
+        <div class="dropzone" id="dropzone">
+          <i class="fas fa-cloud-upload-alt fa-3x"></i>
+          <p>Drag &amp; drop or click to browse</p>
+          <input type="file" id="file-input" accept=".xml,.html" hidden />
+        </div>
+        <div id="upload-status" class="status"></div>
+      </section>
+      <section class="card reports-card" id="reports-section">
+        <div class="card-header">
+          <h2>Existing Reports</h2>
+          <div class="controls">
+            <input type="text" id="table-search" placeholder="Search reports…" />
+            <button id="export-btn"><i class="fas fa-file-export"></i> Export</button>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table id="reports-table">
+            <thead>
+              <tr>
+                <th>Domain</th><th>Date</th><th>Global</th>
+                <th>StaleObjects</th><th>PrivilegedAccounts</th>
+                <th>Trusts</th><th>Anomalies</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </div>
+</div>
+<div id="modal" class="modal hidden">
+  <div class="modal-content">
+    <span id="modal-close" class="modal-close">&times;</span>
+    <h2>Report Details</h2>
+    <div class="sort-controls">
+      <label for="sort-select">Sort by:</label>
+      <select id="sort-select">
+        <option value="category">Category</option>
+        <option value="name">Name</option>
+        <option value="score_desc">Score (high→low)</option>
+        <option value="score_asc">Score (low→high)</option>
+      </select>
+    </div>
+    <div class="table-wrap">
+      <table id="findings-table">
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Name</th>
+            <th>Score</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+<script type="module" src="app.js"></script>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -102,6 +102,7 @@ tbody td {
 }
 tbody tr:nth-child(even) { background: var(--gray-lighter); }
 tbody tr:hover { background: #e3f2fd; }
+tbody tr { cursor: pointer; }
 
 /* Details Modal */
 .modal {

--- a/main.py
+++ b/main.py
@@ -63,12 +63,12 @@ async def upload_pingcastle_report(
     return JSONResponse({"status": "success", "report_id": report.id})
 
 
-@app.get("/reports", response_model=List[ReportSummary])
+@app.get("/api/reports", response_model=List[ReportSummary])
 def list_reports(storage: ReportStorage = Depends(get_storage)):
     return storage.get_all_reports_summary()
 
 
-@app.get("/reports/{report_id}", response_model=Report)
+@app.get("/api/reports/{report_id}", response_model=Report)
 def get_report(report_id: str, storage: ReportStorage = Depends(get_storage)):
     try:
         return storage.get_report(report_id)
@@ -92,6 +92,12 @@ def analysis_frequency(storage: ReportStorage = Depends(get_storage)):
 def analyze_page():
     # Serve the standalone analysis page
     return FileResponse(BASE_DIR / "frontend" / "analyze.html")
+
+
+@app.get("/reports")
+def reports_page():
+    # Serve the reports page
+    return FileResponse(BASE_DIR / "frontend" / "reports.html")
 
 
 # Mount all other paths to your frontend


### PR DESCRIPTION
## Summary
- move dashboard info and historical chart to a simplified `index.html`
- implement new `reports.html` with upload and table
- add `home.js` to load chart and domain info
- make report rows clickable and fetch details via new `/api/reports` endpoints
- serve reports page from backend

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6878ec2f40d4832daaf170b1dc485bfe