### PR TITLE
Add domain info details

### DIFF
--- a/frontend/home.js
+++ b/frontend/home.js
@@ -13,6 +13,16 @@ async function loadDomainInfo() {
       const latest = reports[reports.length - 1];
       document.getElementById('domain-name').textContent = latest.domain;
       document.getElementById('latest-date').textContent = new Date(latest.report_date).toLocaleDateString();
+
+      const detailRes = await fetch(`/api/reports/${latest.id}`);
+      const detail = await detailRes.json();
+      document.getElementById('domain-sid').textContent = detail.domain_sid;
+      document.getElementById('domain-func').textContent = detail.domain_functional_level;
+      document.getElementById('forest-func').textContent = detail.forest_functional_level;
+      document.getElementById('maturity-level').textContent = detail.maturity_level;
+      document.getElementById('dc-count').textContent = detail.dc_count;
+      document.getElementById('user-count').textContent = detail.user_count;
+      document.getElementById('computer-count').textContent = detail.computer_count;
     }
   } catch {
     // ignore

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,6 +26,13 @@
         <h2>Domain Information</h2>
         <p>Domain: <span id="domain-name">-</span></p>
         <p>Latest Scan: <span id="latest-date">-</span></p>
+        <p>Domain SID: <span id="domain-sid">-</span></p>
+        <p>Domain Functional Level: <span id="domain-func">-</span></p>
+        <p>Forest Functional Level: <span id="forest-func">-</span></p>
+        <p>Maturity Level: <span id="maturity-level">-</span></p>
+        <p>Number of DCs: <span id="dc-count">-</span></p>
+        <p>Number of Users: <span id="user-count">-</span></p>
+        <p>Number of Computers: <span id="computer-count">-</span></p>
       </section>
       <section class="card" id="analyze-section">
         <div class="card-header"><h2>Score History</h2></div>

--- a/models.py
+++ b/models.py
@@ -25,6 +25,13 @@ class ReportSummary(BaseModel):
     privileged_accounts_score: int
     trusts_score: int
     anomalies_score: int
+    domain_sid: str
+    domain_functional_level: str
+    forest_functional_level: str
+    maturity_level: str
+    dc_count: int
+    user_count: int
+    computer_count: int
 
 class Report(BaseModel):
     id: str
@@ -40,5 +47,12 @@ class Report(BaseModel):
     privileged_accounts_score: int
     trusts_score: int
     anomalies_score: int
+    domain_sid: str
+    domain_functional_level: str
+    forest_functional_level: str
+    maturity_level: str
+    dc_count: int
+    user_count: int
+    computer_count: int
     original_file: Optional[str] = None
     findings: List[Finding]

--- a/parser.py
+++ b/parser.py
@@ -57,9 +57,22 @@ class PingCastleParser:
         medium_score = get_int("./ScoreSystem/MediumScore")
         low_score    = get_int("./ScoreSystem/LowScore")
 
-        dc_count = get_int_any("./DomainControllerCount", "./NumberOfDCs", "./NbDC")
-        user_count = get_int_any("./NumberOfUsers", "./NbUsers")
-        computer_count = get_int_any("./NumberOfComputers", "./NbComputers")
+        dc_count = get_int_any(
+            "./NumberOfDC",
+            "./DomainControllerCount",
+            "./NumberOfDCs",
+            "./NbDC",
+        )
+        user_count = get_int_any(
+            "./UserAccountData/Number",
+            "./NumberOfUsers",
+            "./NbUsers",
+        )
+        computer_count = get_int_any(
+            "./ComputerAccountData/Number",
+            "./NumberOfComputers",
+            "./NbComputers",
+        )
 
         # Build per‑category totals
         categories = {

--- a/parser.py
+++ b/parser.py
@@ -12,6 +12,18 @@ class PingCastleParser:
         # Extract domain
         domain = root.findtext("./DomainFQDN") or ""
 
+        def get_text(*paths: str) -> str:
+            for p in paths:
+                val = root.findtext(p)
+                if val:
+                    return val
+            return ""
+
+        domain_sid = get_text("./DomainSID", "./DomainSid")
+        domain_functional = get_text("./DomainFunctionalLevel")
+        forest_functional = get_text("./ForestFunctionalLevel")
+        maturity_level = get_text("./MaturityLevel")
+
         # Parse generation date
         date_str = root.findtext("./GenerationDate") or ""
         try:
@@ -30,10 +42,24 @@ class PingCastleParser:
             except ValueError:
                 raise ValueError(f"Invalid integer '{t}' at '{xpath}'")
 
+        def get_int_any(*xpaths: str) -> int:
+            for xp in xpaths:
+                t = root.findtext(xp)
+                if t:
+                    try:
+                        return int(t)
+                    except ValueError:
+                        raise ValueError(f"Invalid integer '{t}' at '{xp}'")
+            return 0
+
         # Still parse these if you need them
         high_score   = get_int("./ScoreSystem/HighScore")
         medium_score = get_int("./ScoreSystem/MediumScore")
         low_score    = get_int("./ScoreSystem/LowScore")
+
+        dc_count = get_int_any("./DomainControllerCount", "./NumberOfDCs", "./NbDC")
+        user_count = get_int_any("./NumberOfUsers", "./NbUsers")
+        computer_count = get_int_any("./NumberOfComputers", "./NbComputers")
 
         # Build per‑category totals
         categories = {
@@ -78,6 +104,13 @@ class PingCastleParser:
         return Report(
             id=report_id,
             domain=domain,
+            domain_sid=domain_sid,
+            domain_functional_level=domain_functional,
+            forest_functional_level=forest_functional,
+            maturity_level=maturity_level,
+            dc_count=dc_count,
+            user_count=user_count,
+            computer_count=computer_count,
             report_date=report_date,
             upload_date=datetime.utcnow(),
             global_score=global_score,                    # <-- replaced PingCastle global


### PR DESCRIPTION
## Summary
- parse additional domain information from PingCastle reports
- store new domain fields in the database
- expose domain details in API responses
- display domain details on the dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687901e38f78832d9daffc35db94e4a3