### PR TITLE
Add midnight blue dark theme with new domain info layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,15 +24,23 @@
     <div class="content">
       <section class="card" id="domain-info">
         <h2>Domain Information</h2>
-        <p>Domain: <span id="domain-name">-</span></p>
-        <p>Latest Scan: <span id="latest-date">-</span></p>
-        <p>Domain SID: <span id="domain-sid">-</span></p>
-        <p>Domain Functional Level: <span id="domain-func">-</span></p>
-        <p>Forest Functional Level: <span id="forest-func">-</span></p>
-        <p>Maturity Level: <span id="maturity-level">-</span></p>
-        <p>Number of DCs: <span id="dc-count">-</span></p>
-        <p>Number of Users: <span id="user-count">-</span></p>
-        <p>Number of Computers: <span id="computer-count">-</span></p>
+        <div class="domain-top">
+          <p>Domain: <span id="domain-name">-</span></p>
+          <p>Domain SID: <span id="domain-sid">-</span></p>
+          <p>Latest Scan: <span id="latest-date">-</span></p>
+        </div>
+        <div class="domain-grid">
+          <div class="domain-col">
+            <p>Domain Functional Level: <span id="domain-func">-</span></p>
+            <p>Forest Functional Level: <span id="forest-func">-</span></p>
+            <p>Maturity Level: <span id="maturity-level">-</span></p>
+            <p>Number of DCs: <span id="dc-count">-</span></p>
+          </div>
+          <div class="domain-col">
+            <p>Number of Users: <span id="user-count">-</span></p>
+            <p>Number of Computers: <span id="computer-count">-</span></p>
+          </div>
+        </div>
       </section>
       <section class="card" id="analyze-section">
         <div class="card-header"><h2>Score History</h2></div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,29 +1,46 @@
 /* Base & fonts */
 @import url('https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap');
 :root {
-  --blue: #1976d2;
-  --blue-dark: #1565c0;
-  --gray-light: #f5f7fa;
-  --gray-lighter: #f9f9f9;
-  --text: #333;
+  /* Midnight blue dark theme colors */
+  --blue: #82b1ff;
+  --blue-dark: #448aff;
+  --gray-light: #0d1b2a;        /* page background */
+  --gray-lighter: #152238;      /* slightly lighter surface */
+  --card-bg: #1b263b;           /* card and sidebar background */
+  --text: #e0e0e0;
+  --border-color: #314056;
 }
 * { box-sizing: border-box; margin: 0; padding: 0; }
-body, input, button, select { font-family: 'Roboto', sans-serif; color: var(--text); }
+body, input, button, select {
+  font-family: 'Roboto', sans-serif;
+  color: var(--text);
+  background: var(--gray-light);
+}
 
 /* App layout */
 .app { display: flex; height: 100vh; }
 .sidebar {
-  width: 200px; background: #fff; border-right: 1px solid #e0e0e0;
-  display: flex; flex-direction: column; 
+  width: 200px;
+  background: var(--card-bg);
+  border-right: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
 }
 .sidebar .logo {
-  font-size: 1.5em; font-weight: 500; padding: 1em;
-  border-bottom: 1px solid #e0e0e0;
+  font-size: 1.5em;
+  font-weight: 500;
+  padding: 1em;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--blue);
 }
 .sidebar nav { flex: 1; }
 .sidebar .nav-item {
-  display: flex; align-items: center; padding: 0.75em 1em;
-  color: #555; text-decoration: none; transition: background .2s;
+  display: flex;
+  align-items: center;
+  padding: 0.75em 1em;
+  color: var(--text);
+  text-decoration: none;
+  transition: background .2s;
 }
 .sidebar .nav-item i { width: 24px; }
 .sidebar .nav-item span { margin-left: 10px; }
@@ -34,21 +51,33 @@ body, input, button, select { font-family: 'Roboto', sans-serif; color: var(--te
 .main { flex: 1; display: flex; flex-direction: column; background: var(--gray-light);}
 .topbar {
   display: flex; justify-content: space-between; align-items: center;
-  padding: 0.75em 1em; background: #fff; border-bottom: 1px solid #e0e0e0;
+  padding: 0.75em 1em;
+  background: var(--card-bg);
+  border-bottom: 1px solid var(--border-color);
 }
 .topbar-search {
   flex: 1; max-width: 400px; position: relative;
 }
 .topbar-search i {
-  position: absolute; top: 50%; left: 10px; transform: translateY(-50%);
-  color: #888;
+  position: absolute;
+  top: 50%;
+  left: 10px;
+  transform: translateY(-50%);
+  color: var(--text);
 }
 .topbar-search input {
-  width: 100%; padding: 0.5em 0.5em 0.5em 2.5em; border-radius: 4px;
-  border: 1px solid #ccc;
+  width: 100%;
+  padding: 0.5em 0.5em 0.5em 2.5em;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  background: var(--gray-lighter);
+  color: var(--text);
 }
 .topbar-actions i {
-  font-size: 1.2em; margin-left: 1em; color: #555; cursor: pointer;
+  font-size: 1.2em;
+  margin-left: 1em;
+  color: var(--text);
+  cursor: pointer;
 }
 .topbar-actions i.avatar { font-size: 2em; }
 
@@ -57,18 +86,26 @@ body, input, button, select { font-family: 'Roboto', sans-serif; color: var(--te
 
 /* Cards */
 .card {
-  background: #fff; border-radius: 8px; padding: 1.25em; margin-bottom: 1.5em;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+  background: var(--card-bg);
+  border-radius: 8px;
+  padding: 1.25em;
+  margin-bottom: 1.5em;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  color: var(--text);
 }
 .upload-card { text-align: center; }
 .upload-card h2 { margin-bottom: 1em; font-weight: 500; }
 .dropzone {
-  border: 2px dashed #ccc; border-radius: 8px; padding: 2em;
-  cursor: pointer; transition: background .2s, border-color .2s;
+  border: 2px dashed var(--border-color);
+  border-radius: 8px;
+  padding: 2em;
+  cursor: pointer;
+  transition: background .2s, border-color .2s;
+  background: var(--gray-lighter);
 }
 .dropzone:hover,
 .dropzone.dragover { background: var(--gray-lighter); border-color: var(--blue); }
-.dropzone p { margin-top: 0.5em; color: #666; }
+.dropzone p { margin-top: 0.5em; color: var(--text); }
 .status { margin-top: 0.75em; font-size: 0.9em; }
 
 /* Reports card header */
@@ -80,8 +117,12 @@ body, input, button, select { font-family: 'Roboto', sans-serif; color: var(--te
   display: flex; align-items: center;
 }
 .reports-card input#table-search {
-  padding: 0.5em; border-radius: 4px; border: 1px solid #ccc;
+  padding: 0.5em;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
   margin-right: 0.75em;
+  background: var(--gray-lighter);
+  color: var(--text);
 }
 .reports-card button#export-btn {
   background: var(--blue); color: #fff; border: none; padding: 0.5em 1em;
@@ -98,10 +139,11 @@ thead th {
   background: var(--blue); color: #fff; padding: 0.75em; text-align: left;
 }
 tbody td {
-  padding: 0.75em; border-bottom: 1px solid #ececec;
+  padding: 0.75em;
+  border-bottom: 1px solid var(--border-color);
 }
 tbody tr:nth-child(even) { background: var(--gray-lighter); }
-tbody tr:hover { background: #e3f2fd; }
+tbody tr:hover { background: var(--blue-dark); }
 tbody tr { cursor: pointer; }
 
 /* Details Modal */
@@ -112,20 +154,35 @@ tbody tr { cursor: pointer; }
 }
 .modal.hidden { display: none; }
 .modal-content {
-  background: #fff; border-radius: 8px; width: 90%; max-width: 700px;
-  max-height: 85vh; overflow-y: auto; padding: 1.5em; position: relative;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  background: var(--card-bg);
+  border-radius: 8px;
+  width: 90%;
+  max-width: 700px;
+  max-height: 85vh;
+  overflow-y: auto;
+  padding: 1.5em;
+  position: relative;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  color: var(--text);
 }
 .modal-close {
-  position: absolute; top: 12px; right: 16px; font-size: 1.5em; cursor: pointer;
-  color: #666;
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  font-size: 1.5em;
+  cursor: pointer;
+  color: var(--text);
 }
 .sort-controls {
   margin: 1em 0 0.5em; display: flex; align-items: center;
 }
 .sort-controls label { margin-right: 0.5em; font-weight: 500; }
 .sort-controls select {
-  padding: 0.5em; border-radius: 4px; border: 1px solid #ccc;
+  padding: 0.5em;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  background: var(--gray-lighter);
+  color: var(--text);
 }
 
 .analysis-container {
@@ -140,11 +197,31 @@ tbody tr { cursor: pointer; }
 }
 .analysis-topbar .back-btn {
   text-decoration: none;
-  color: #1976d2;
+  color: var(--blue);
   font-size: 0.9em;
   margin-right: 1em;
 }
 .analysis-topbar h1 {
   font-weight: 500;
   font-size: 1.5em;
+  color: var(--text);
+}
+
+/* Domain info layout */
+#domain-info .domain-top {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+  margin-bottom: 0.5em;
+}
+#domain-info .domain-top p {
+  margin: 0;
+}
+#domain-info .domain-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1em;
+}
+#domain-info .domain-col p {
+  margin: 0.25em 0;
 }


### PR DESCRIPTION
## Summary
- refresh styling with a midnight blue dark theme
- redesign domain information card using a two‑column grid

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879170f80a4832d8977508a1a43ee65