### PR TITLE
Improve risk gauge layout and orientation

### DIFF
--- a/frontend/home.js
+++ b/frontend/home.js
@@ -75,7 +75,7 @@ function makeGauge(ctx, value){
       }]
     },
     options: {
-      rotation: Math.PI,           // start at 180°
+      rotation: -Math.PI,          // start at 9‑o'clock
       circumference: Math.PI,      // sweep 180°
       cutout: '70%',               // thickness
       plugins: {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -228,14 +228,16 @@ tbody tr { cursor: pointer; }
 
 /* Risk scores layout */
 #risk-scores .risk-global {
-  margin-bottom: 0.5em;
+  margin-bottom: 1em;
   font-weight: 500;
+  text-align: center;
+  font-size: 1.4em;
 }
 #risk-scores .risk-grid {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  justify-items: center;
   gap: 2rem;
-  justify-content: center;
-  flex-wrap: wrap;
   max-width: 650px;
   margin: 0 auto;
 }
@@ -250,7 +252,7 @@ tbody tr { cursor: pointer; }
   padding: 0;
 }
 
-.risk-gauge convas {
+.risk-gauge canvas {
   width: 100%;
   height: auto;
   aspect-ratio: 2 / 1;


### PR DESCRIPTION
## Summary
- center the global risk score text and use a responsive grid for gauges
- correct the CSS selector for gauge canvases
- start gauges at 9-o'clock for a half-dial appearance

## Testing
- `python -m py_compile main.py models.py parser.py storage.py`

------
https://chatgpt.com/codex/tasks/task_e_687a3ccfd7a8832db1394a3d0079796b