### PR TITLE
Fix gauge orientation

### DIFF
--- a/frontend/home.js
+++ b/frontend/home.js
@@ -76,7 +76,7 @@ function makeGauge(ctx, value){
     },
     options: {
       beginAtZero: true,
-      rotation: -Math.PI,          // start at 9‑o'clock
+      rotation: Math.PI,           // start at 9 o'clock
       circumference: Math.PI,      // sweep 180°
       cutout: '70%',               // thickness
       plugins: {


### PR DESCRIPTION
## Summary
- tweak rotation so the risk gauges sweep bottom up correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a958807d4832d897b600f5ccfc79c