### PR TITLE
Add risk acceptance and webhook alerting

### DIFF
--- a/frontend/analyze.html
+++ b/frontend/analyze.html
@@ -23,7 +23,7 @@
         <h3>Recurring Findings</h3>
         <table id="recurring-table">
           <thead><tr>
-            <th>Category</th><th>Name</th><th>Count</th>
+            <th>Category</th><th>Name</th><th>Count</th><th>Action</th>
           </tr></thead>
           <tbody></tbody>
         </table>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,7 @@
         <a href="/" class="nav-item active"><i class="fas fa-tachometer-alt"></i><span>Dashboard</span></a>
         <a href="/reports" class="nav-item"><i class="fas fa-file-alt"></i><span>Reports</span></a>
         <a href="/analyze" class="nav-item"><i class="fas fa-chart-line"></i><span>Analyze</span></a>
+        <a href="/settings" class="nav-item"><i class="fas fa-gear"></i><span>Settings</span></a>
       </nav>
     </aside>
     <div class="main">

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Settings</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="analysis-container">
+    <header class="analysis-topbar">
+      <a href="/" class="back-btn"><i class="fas fa-arrow-left"></i> Back</a>
+      <h1>Settings</h1>
+    </header>
+
+    <section class="card analyze-card" id="settings-section">
+      <div class="card-header"><h2>Alert Settings</h2></div>
+      <form id="settings-form" class="settings-form">
+        <label>Webhook URL
+          <input type="text" id="webhook" />
+        </label>
+        <label>Message
+          <input type="text" id="message" />
+        </label>
+        <button type="submit">Save</button>
+      </form>
+    </section>
+
+    <section class="card analyze-card" id="log-section">
+      <div class="card-header"><h2>Alert Log</h2></div>
+      <table id="log-table">
+        <thead><tr><th>Time</th><th>Message</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  </div>
+
+  <script type="module" src="settings.js"></script>
+</body>
+</html>

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -1,0 +1,32 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const form = document.getElementById("settings-form");
+  const webhook = document.getElementById("webhook");
+  const message = document.getElementById("message");
+  const logBody = document.querySelector("#log-table tbody");
+
+  async function load() {
+    const [settings, log] = await Promise.all([
+      fetch("/api/settings").then(r => r.json()),
+      fetch("/api/alerts/log").then(r => r.json()),
+    ]);
+    webhook.value = settings.webhook_url || "";
+    message.value = settings.alert_message || "";
+    logBody.innerHTML = "";
+    log.forEach(entry => {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `<td>${new Date(entry.timestamp).toLocaleString()}</td><td>${entry.message}</td>`;
+      logBody.appendChild(tr);
+    });
+  }
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    await fetch("/api/settings", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({webhook_url: webhook.value, alert_message: message.value})
+    });
+  });
+
+  load();
+});

--- a/models.py
+++ b/models.py
@@ -56,3 +56,18 @@ class Report(BaseModel):
     computer_count: int
     original_file: Optional[str] = None
     findings: List[Finding]
+
+
+class AcceptedRisk(BaseModel):
+    category: str
+    name: str
+
+
+class Settings(BaseModel):
+    webhook_url: str = ""
+    alert_message: str = ""
+
+
+class AlertLog(BaseModel):
+    timestamp: datetime
+    message: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ uvicorn
 aiofiles
 defusedxml
 pydantic
+requests


### PR DESCRIPTION
## Summary
- allow marking recurring findings as accepted risk and store settings
- alert via configurable webhook for unaccepted findings and log attempts
- add settings page with alert configuration and logbook

## Testing
- `python -m py_compile main.py models.py storage.py parser.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689097350c74832da86db362bcec6eb6